### PR TITLE
fixes #1 initial terraform to deploy ranger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2018-08-28
+## [Unreleased]
 ### Added
-- initial terraform: https://github.com/ExpediaInc/apiary-authorization/issues/1
+- initial terraform: See [#1](https://github.com/ExpediaInc/apiary-authorization/issues/1)
 - Aurora database for storing ranger configs and audit logs
 - ranger admin service HA configuration with sticky sessions.
 - ranger usersync service to sync ldap users and groups from Active Directory
 - read database master password from vault
 - route53 dns entries for ranger admin & database
-- *solr based auditing is not included in intial commit.
+- solr based auditing is not included in intial commit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 2018-08-28
+### Added
+- initial terraform: https://github.com/ExpediaInc/apiary-authorization/issues/1
+- Aurora database for storing ranger configs and audit logs
+- ranger admin service HA configuration with sticky sessions.
+- ranger usersync service to sync ldap users and groups from Active Directory
+- read database master password from vault
+- route53 dns entries for ranger admin & database
+- *solr based auditing is not included in intial commit.

--- a/common.tf
+++ b/common.tf
@@ -1,0 +1,12 @@
+locals {
+  vault_path = "${ var.vault_path == "" ? format("secret/apiary-ranger-%s",var.aws_region) : var.vault_path }"
+}
+
+data "aws_vpc" "apiary_vpc" {
+  id = "${var.vpc_id}"
+}
+
+data "aws_route53_zone" "ranger_zone" {
+  name   = "${var.ranger_domain_name}"
+  vpc_id = "${var.vpc_id}"
+}

--- a/db.tf
+++ b/db.tf
@@ -1,0 +1,90 @@
+/**
+ * Copyright (C) 2018 Expedia Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+resource "aws_db_subnet_group" "ranger" {
+  name        = "ranger-dbsg"
+  subnet_ids  = ["${var.private_subnets}"]
+  description = "Apiary Ranger DB Subnet Group"
+  tags        = "${var.apiary_tags}"
+}
+
+data "vault_generic_secret" "ranger_db_master_user" {
+  path = "${local.vault_path}/ranger_db_master_user"
+}
+
+resource "aws_security_group" "ranger_db" {
+  name   = "ranger-db"
+  vpc_id = "${var.vpc_id}"
+  tags   = "${var.apiary_tags}"
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["${data.aws_vpc.apiary_vpc.cidr_block}"]
+    self        = true
+  }
+
+  ingress {
+    from_port   = 3306
+    to_port     = 3306
+    protocol    = "tcp"
+    cidr_blocks = "${var.ranger_db_ingress_cidr}"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+    self        = true
+  }
+}
+
+resource "random_id" "snapshot_id" {
+  byte_length = 8
+}
+
+resource "aws_rds_cluster" "ranger_cluster" {
+  cluster_identifier                  = "ranger-cluster"
+  database_name                       = "${var.ranger_database_name}"
+  master_username                     = "${data.vault_generic_secret.ranger_db_master_user.data["username"]}"
+  master_password                     = "${data.vault_generic_secret.ranger_db_master_user.data["password"]}"
+  backup_retention_period             = "${var.ranger_db_backup_retention}"
+  preferred_backup_window             = "${var.ranger_db_backup_window}"
+  preferred_maintenance_window        = "${var.ranger_db_maintenance_window}"
+  db_subnet_group_name                = "${aws_db_subnet_group.ranger.name}"
+  vpc_security_group_ids              = ["${compact(concat(list(aws_security_group.ranger_db.id), var.ranger_db_additional_sg))}"]
+  tags                                = "${var.apiary_tags}"
+  final_snapshot_identifier           = "ranger-cluster-final-${random_id.snapshot_id.hex}"
+  iam_database_authentication_enabled = true
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_rds_cluster_instance" "ranger_cluster_instance" {
+  count                = "${var.ranger_db_instance_count}"
+  identifier           = "ranger-instance-${count.index}"
+  cluster_identifier   = "${aws_rds_cluster.ranger_cluster.id}"
+  instance_class       = "${var.ranger_db_instance_class}"
+  db_subnet_group_name = "${aws_db_subnet_group.ranger.name}"
+  publicly_accessible  = false
+  tags                 = "${var.apiary_tags}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "ranger_database" {
+  zone_id = "${data.aws_route53_zone.ranger_zone.zone_id}"
+  name    = "ranger-database"
+  type    = "CNAME"
+  ttl     = "60"
+  records = [ "${aws_rds_cluster.ranger_cluster.endpoint}" ]
+}

--- a/iam.tf
+++ b/iam.tf
@@ -1,0 +1,44 @@
+resource "aws_iam_role" "ranger_task_exec" {
+  name = "ranger-ecs-task-exec-${var.aws_region}"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ecs-tasks.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "task_exec_managed" {
+  role       = "${aws_iam_role.ranger_task_exec.id}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role" "ranger_task" {
+  name = "ranger-ecs-task-${var.aws_region}"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ecs-tasks.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}

--- a/iam.tf
+++ b/iam.tf
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2018 Expedia Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
 resource "aws_iam_role" "ranger_task_exec" {
   name = "ranger-ecs-task-exec-${var.aws_region}"
 
@@ -18,7 +24,7 @@ resource "aws_iam_role" "ranger_task_exec" {
 EOF
 }
 
-resource "aws_iam_role_policy_attachment" "task_exec_managed" {
+resource "aws_iam_role_policy_attachment" "ranger_task_exec_policy" {
   role       = "${aws_iam_role.ranger_task_exec.id}"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }

--- a/output.tf
+++ b/output.tf
@@ -1,0 +1,6 @@
+/**
+ * Copyright (C) 2018 Expedia Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+

--- a/output.tf
+++ b/output.tf
@@ -1,6 +1,0 @@
-/**
- * Copyright (C) 2018 Expedia Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- */
-

--- a/provider.tf
+++ b/provider.tf
@@ -1,0 +1,9 @@
+/**
+ * Copyright (C) 2018 Expedia Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+terraform {
+  required_version = "~> 0.11"
+}

--- a/ranger.tf
+++ b/ranger.tf
@@ -1,0 +1,375 @@
+resource "aws_ecs_cluster" "ranger" {
+  name = "ranger"
+}
+
+resource "aws_cloudwatch_log_group" "ranger" {
+  name = "ranger"
+  tags = "${var.apiary_tags}"
+}
+
+data "vault_generic_secret" "ranger_admin" {
+  path = "${local.vault_path}/ranger_admin"
+}
+
+data "template_file" "ranger_admin" {
+  template = <<EOF
+[
+  {
+    "name": "ranger-admin",
+    "image": "${var.ranger_docker_image}:${var.ranger_docker_version}",
+    "command": [ "/start-ranger-admin.sh" ],
+    "essential": true,
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+            "awslogs-group": "${aws_cloudwatch_log_group.ranger.name}",
+            "awslogs-region": "${var.aws_region}",
+            "awslogs-stream-prefix": "/"
+        }
+    },
+    "portMappings": [
+      {
+        "containerPort": 6080,
+        "hostPort": 6080
+      }
+    ],
+    "environment":[
+     {
+        "name": "HEAPSIZE",
+        "value": "${var.ranger_admin_task_memory}"
+     },
+     {
+        "name": "AWS_REGION",
+        "value": "${var.aws_region}"
+     },
+     {
+        "name": "VAULT_ADDR",
+        "value": "${var.vault_internal_addr}"
+     },
+     {
+        "name": "vault_path",
+        "value": "${local.vault_path}"
+     },
+     {
+        "name": "db_host",
+        "value": "${aws_rds_cluster.ranger_cluster.endpoint}"
+     },
+     {
+        "name": "db_name",
+        "value": "${aws_rds_cluster.ranger_cluster.database_name}"
+     },
+     {
+        "name": "xa_ldap_ad_url",
+        "value": "${replace(var.ldap_url,"/","\\\\/")}"
+     },
+     {
+        "name": "audit_solr_urls",
+        "value": "${replace(var.audit_solr_urls,"/","\\\\/")}"
+     },
+     {
+        "name": "xa_ldap_ad_base_dn",
+        "value": "${var.ldap_base}"
+     },
+     {
+        "name": "xa_ldap_ad_domain",
+        "value": "${var.ldap_domain}"
+     },
+     {
+        "name": "LOGLEVEL",
+        "value": "${var.ranger_admin_loglevel}"
+     }
+    ]
+  }
+]
+EOF
+}
+
+resource "aws_ecs_task_definition" "ranger_admin" {
+  family                   = "ranger-admin"
+  task_role_arn            = "${aws_iam_role.ranger_task.arn}"
+  execution_role_arn       = "${aws_iam_role.ranger_task_exec.arn}"
+  network_mode             = "awsvpc"
+  memory                   = "${var.ranger_admin_task_memory}"
+  cpu                      = "${var.ranger_admin_task_cpu}"
+  requires_compatibilities = ["EC2", "FARGATE"]
+  container_definitions    = "${data.template_file.ranger_admin.rendered}"
+}
+
+resource "aws_security_group" "ranger_admin" {
+  name   = "ranger-admin"
+  vpc_id = "${var.vpc_id}"
+  tags   = "${var.apiary_tags}"
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = "${var.ranger_admin_ingress_cidr}"
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = "${var.ranger_admin_ingress_cidr}"
+  }
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["${data.aws_vpc.apiary_vpc.cidr_block}"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "ranger_usersync" {
+  name   = "ranger-usersync"
+  vpc_id = "${var.vpc_id}"
+  tags   = "${var.apiary_tags}"
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["${data.aws_vpc.apiary_vpc.cidr_block}"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_ecs_service" "ranger_service" {
+  name            = "ranger-admin-service"
+  launch_type     = "FARGATE"
+  cluster         = "${aws_ecs_cluster.ranger.id}"
+  task_definition = "${aws_ecs_task_definition.ranger_admin.arn}"
+  desired_count   = "${var.ranger_admin_instance_count}"
+
+  network_configuration {
+    security_groups = ["${aws_security_group.ranger_admin.id}"]
+    subnets         = ["${var.private_subnets}"]
+  }
+
+  load_balancer {
+    target_group_arn = "${aws_lb_target_group.ranger_admin_tg.arn}"
+    container_name   = "ranger-admin"
+    container_port   = 6080
+  }
+  depends_on = [ "aws_lb_target_group.ranger_admin_tg", "aws_rds_cluster_instance.ranger_cluster_instance" ]
+}
+
+resource "aws_lb" "ranger_admin_lb" {
+  name               = "ranger-admin-lb"
+  load_balancer_type = "application"
+  security_groups    = ["${aws_security_group.ranger_admin.id}"]
+  subnets            = ["${var.private_subnets}"]
+  internal           = true
+  tags               = "${var.apiary_tags}"
+}
+
+resource "aws_route53_record" "ranger_admin" {
+  zone_id = "${data.aws_route53_zone.ranger_zone.zone_id}"
+  name    = "ranger-admin"
+  type    = "A"
+
+  alias {
+    name                   = "${aws_lb.ranger_admin_lb.dns_name}"
+    zone_id                = "${aws_lb.ranger_admin_lb.zone_id}"
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_lb_target_group" "ranger_admin_tg" {
+  name        = "ranger-admin-tg"
+  port        = 6080
+  protocol    = "HTTP"
+  vpc_id      = "${var.vpc_id}"
+  target_type = "ip"
+  slow_start  = 900
+
+  stickiness {
+    type = "lb_cookie"
+    enabled = true
+  }
+
+  health_check {
+    healthy_threshold   = 5
+    unhealthy_threshold = 10
+    protocol            = "HTTP"
+    interval            = 30
+    timeout             = 5
+    matcher             = 200
+    path                = "/login.jsp"
+  }
+  depends_on  = ["aws_lb.ranger_admin_lb"]
+}
+
+data "vault_generic_secret" "ranger_admin_cert" {
+  path = "${local.vault_path}/${aws_route53_record.ranger_admin.fqdn}"
+}
+
+resource "aws_iam_server_certificate" "ranger_admin" {
+  name             = "ranger-admin"
+  certificate_body = "${data.vault_generic_secret.ranger_admin_cert.data["crt"]}"
+  private_key      = "${data.vault_generic_secret.ranger_admin_cert.data["pem"]}"
+}
+
+resource "aws_lb_listener" "ranger_http_listener" {
+  load_balancer_arn = "${aws_lb.ranger_admin_lb.arn}"
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_lb_listener" "ranger_https_listener" {
+  load_balancer_arn = "${aws_lb.ranger_admin_lb.arn}"
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-2015-05"
+  certificate_arn   = "${aws_iam_server_certificate.ranger_admin.arn}"
+
+  default_action {
+    target_group_arn = "${aws_lb_target_group.ranger_admin_tg.arn}"
+    type             = "forward"
+  }
+}
+
+resource "aws_lb_listener" "ranger_listener" {
+  load_balancer_arn = "${aws_lb.ranger_admin_lb.arn}"
+  port              = "6080"
+  protocol          = "HTTP"
+
+  default_action {
+    target_group_arn = "${aws_lb_target_group.ranger_admin_tg.arn}"
+    type             = "forward"
+  }
+}
+
+data "template_file" "ranger_usersync" {
+  template = <<EOF
+[
+  {
+    "name": "ranger-usersync",
+    "image": "${var.ranger_docker_image}:${var.ranger_docker_version}",
+    "command": [ "/start-ranger-usersync.sh" ],
+    "essential": true,
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+            "awslogs-group": "${aws_cloudwatch_log_group.ranger.name}",
+            "awslogs-region": "${var.aws_region}",
+            "awslogs-stream-prefix": "/"
+        }
+    },
+    "environment":[
+     {
+        "name": "HEAPSIZE",
+        "value": "${var.ranger_usersync_task_memory}"
+     },
+     {
+        "name": "AWS_REGION",
+        "value": "${var.aws_region}"
+     },
+     {
+        "name": "VAULT_ADDR",
+        "value": "${var.vault_internal_addr}"
+     },
+     {
+        "name": "vault_path",
+        "value": "${local.vault_path}"
+     },
+     {
+        "name": "POLICY_MGR_URL",
+        "value": "http:\\/\\/${aws_lb.ranger_admin_lb.dns_name}:6080"
+     },
+     {
+        "name": "SYNC_LDAP_URL",
+        "value": "${replace(var.ldap_url,"/","\\\\/")}"
+
+     },
+     {
+        "name": "SYNC_LDAP_SEARCH_BASE",
+        "value": "${var.ldap_base}"
+     },
+     {
+        "name": "SYNC_LDAP_USER_SEARCH_BASE",
+        "value": "${var.ldap_user_base}"
+     },
+     {
+        "name": "SYNC_GROUP_SEARCH_BASE",
+        "value": "${var.ldap_group_base}"
+     },
+     {
+        "name": "SYNC_LDAP_USER_NAME_ATTRIBUTE",
+        "value": "sAMAccountName"
+     },
+     {
+        "name": "SYNC_GROUP_NAME_ATTRIBUTE",
+        "value": "sAMAccountName"
+     },
+     {
+        "name": "SYNC_PAGED_RESULTS_SIZE",
+        "value": "1000"
+     },
+     {
+        "name": "SYNC_INTERVAL",
+        "value": "${var.ldap_sync_interval}"
+     },
+     {
+        "name": "GROUP_BASED_ROLE_ASSIGNMENT_RULES",
+        "value": "${ var.ranger_admin_ldap_groups == "" ? "" : "\\\\&ROLE_SYS_ADMIN:g:${var.ranger_admin_ldap_groups}" }"
+     },
+     {
+        "name": "LOGLEVEL",
+        "value": "${var.ranger_usersync_loglevel}"
+     }
+    ]
+  }
+]
+EOF
+}
+
+resource "aws_ecs_task_definition" "ranger_usersync" {
+  family                   = "ranger-usersync"
+  task_role_arn            = "${aws_iam_role.ranger_task.arn}"
+  execution_role_arn       = "${aws_iam_role.ranger_task_exec.arn}"
+  network_mode             = "awsvpc"
+  memory                   = "${var.ranger_usersync_task_memory}"
+  cpu                      = "${var.ranger_usersync_task_cpu}"
+  requires_compatibilities = ["EC2", "FARGATE"]
+  container_definitions    = "${data.template_file.ranger_usersync.rendered}"
+}
+
+resource "aws_ecs_service" "ranger_usersync" {
+  name            = "ranger-usersync"
+  launch_type     = "FARGATE"
+  cluster         = "${aws_ecs_cluster.ranger.id}"
+  task_definition = "${aws_ecs_task_definition.ranger_usersync.arn}"
+  desired_count   = "1"
+
+  network_configuration {
+    security_groups = ["${aws_security_group.ranger_usersync.id}"]
+    subnets         = ["${var.private_subnets}"]
+  }
+  depends_on = [ "aws_ecs_service.ranger_service" ]
+}

--- a/ranger.tf
+++ b/ranger.tf
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2018 Expedia Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
 resource "aws_ecs_cluster" "ranger" {
   name = "ranger"
 }
@@ -9,79 +15,6 @@ resource "aws_cloudwatch_log_group" "ranger" {
 
 data "vault_generic_secret" "ranger_admin" {
   path = "${local.vault_path}/ranger_admin"
-}
-
-data "template_file" "ranger_admin" {
-  template = <<EOF
-[
-  {
-    "name": "ranger-admin",
-    "image": "${var.ranger_docker_image}:${var.ranger_docker_version}",
-    "command": [ "/start-ranger-admin.sh" ],
-    "essential": true,
-    "logConfiguration": {
-        "logDriver": "awslogs",
-        "options": {
-            "awslogs-group": "${aws_cloudwatch_log_group.ranger.name}",
-            "awslogs-region": "${var.aws_region}",
-            "awslogs-stream-prefix": "/"
-        }
-    },
-    "portMappings": [
-      {
-        "containerPort": 6080,
-        "hostPort": 6080
-      }
-    ],
-    "environment":[
-     {
-        "name": "HEAPSIZE",
-        "value": "${var.ranger_admin_task_memory}"
-     },
-     {
-        "name": "AWS_REGION",
-        "value": "${var.aws_region}"
-     },
-     {
-        "name": "VAULT_ADDR",
-        "value": "${var.vault_internal_addr}"
-     },
-     {
-        "name": "vault_path",
-        "value": "${local.vault_path}"
-     },
-     {
-        "name": "db_host",
-        "value": "${aws_rds_cluster.ranger_cluster.endpoint}"
-     },
-     {
-        "name": "db_name",
-        "value": "${aws_rds_cluster.ranger_cluster.database_name}"
-     },
-     {
-        "name": "xa_ldap_ad_url",
-        "value": "${replace(var.ldap_url,"/","\\\\/")}"
-     },
-     {
-        "name": "audit_solr_urls",
-        "value": "${replace(var.audit_solr_urls,"/","\\\\/")}"
-     },
-     {
-        "name": "xa_ldap_ad_base_dn",
-        "value": "${var.ldap_base}"
-     },
-     {
-        "name": "xa_ldap_ad_domain",
-        "value": "${var.ldap_domain}"
-     },
-     {
-        "name": "LOGLEVEL",
-        "value": "${var.ranger_admin_loglevel}"
-     }
-    ]
-  }
-]
-EOF
 }
 
 resource "aws_ecs_task_definition" "ranger_admin" {
@@ -263,90 +196,6 @@ resource "aws_lb_listener" "ranger_listener" {
     target_group_arn = "${aws_lb_target_group.ranger_admin_tg.arn}"
     type             = "forward"
   }
-}
-
-data "template_file" "ranger_usersync" {
-  template = <<EOF
-[
-  {
-    "name": "ranger-usersync",
-    "image": "${var.ranger_docker_image}:${var.ranger_docker_version}",
-    "command": [ "/start-ranger-usersync.sh" ],
-    "essential": true,
-    "logConfiguration": {
-        "logDriver": "awslogs",
-        "options": {
-            "awslogs-group": "${aws_cloudwatch_log_group.ranger.name}",
-            "awslogs-region": "${var.aws_region}",
-            "awslogs-stream-prefix": "/"
-        }
-    },
-    "environment":[
-     {
-        "name": "HEAPSIZE",
-        "value": "${var.ranger_usersync_task_memory}"
-     },
-     {
-        "name": "AWS_REGION",
-        "value": "${var.aws_region}"
-     },
-     {
-        "name": "VAULT_ADDR",
-        "value": "${var.vault_internal_addr}"
-     },
-     {
-        "name": "vault_path",
-        "value": "${local.vault_path}"
-     },
-     {
-        "name": "POLICY_MGR_URL",
-        "value": "http:\\/\\/${aws_lb.ranger_admin_lb.dns_name}:6080"
-     },
-     {
-        "name": "SYNC_LDAP_URL",
-        "value": "${replace(var.ldap_url,"/","\\\\/")}"
-
-     },
-     {
-        "name": "SYNC_LDAP_SEARCH_BASE",
-        "value": "${var.ldap_base}"
-     },
-     {
-        "name": "SYNC_LDAP_USER_SEARCH_BASE",
-        "value": "${var.ldap_user_base}"
-     },
-     {
-        "name": "SYNC_GROUP_SEARCH_BASE",
-        "value": "${var.ldap_group_base}"
-     },
-     {
-        "name": "SYNC_LDAP_USER_NAME_ATTRIBUTE",
-        "value": "sAMAccountName"
-     },
-     {
-        "name": "SYNC_GROUP_NAME_ATTRIBUTE",
-        "value": "sAMAccountName"
-     },
-     {
-        "name": "SYNC_PAGED_RESULTS_SIZE",
-        "value": "1000"
-     },
-     {
-        "name": "SYNC_INTERVAL",
-        "value": "${var.ldap_sync_interval}"
-     },
-     {
-        "name": "GROUP_BASED_ROLE_ASSIGNMENT_RULES",
-        "value": "${ var.ranger_admin_ldap_groups == "" ? "" : "\\\\&ROLE_SYS_ADMIN:g:${var.ranger_admin_ldap_groups}" }"
-     },
-     {
-        "name": "LOGLEVEL",
-        "value": "${var.ranger_usersync_loglevel}"
-     }
-    ]
-  }
-]
-EOF
 }
 
 resource "aws_ecs_task_definition" "ranger_usersync" {

--- a/templates.tf
+++ b/templates.tf
@@ -1,0 +1,162 @@
+/**
+ * Copyright (C) 2018 Expedia Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+data "template_file" "ranger_admin" {
+  template = <<EOF
+[
+  {
+    "name": "ranger-admin",
+    "image": "${var.ranger_docker_image}:${var.ranger_docker_version}",
+    "command": [ "/start-ranger-admin.sh" ],
+    "essential": true,
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+            "awslogs-group": "${aws_cloudwatch_log_group.ranger.name}",
+            "awslogs-region": "${var.aws_region}",
+            "awslogs-stream-prefix": "/"
+        }
+    },
+    "portMappings": [
+      {
+        "containerPort": 6080,
+        "hostPort": 6080
+      }
+    ],
+    "environment":[
+     {
+        "name": "HEAPSIZE",
+        "value": "${var.ranger_admin_task_memory}"
+     },
+     {
+        "name": "AWS_REGION",
+        "value": "${var.aws_region}"
+     },
+     {
+        "name": "VAULT_ADDR",
+        "value": "${var.vault_internal_addr}"
+     },
+     {
+        "name": "vault_path",
+        "value": "${local.vault_path}"
+     },
+     {
+        "name": "db_host",
+        "value": "${aws_rds_cluster.ranger_cluster.endpoint}"
+     },
+     {
+        "name": "db_name",
+        "value": "${aws_rds_cluster.ranger_cluster.database_name}"
+     },
+     {
+        "name": "xa_ldap_ad_url",
+        "value": "${replace(var.ldap_url,"/","\\\\/")}"
+     },
+     {
+        "name": "audit_solr_urls",
+        "value": "${replace(var.audit_solr_urls,"/","\\\\/")}"
+     },
+     {
+        "name": "xa_ldap_ad_base_dn",
+        "value": "${var.ldap_base}"
+     },
+     {
+        "name": "xa_ldap_ad_domain",
+        "value": "${var.ldap_domain}"
+     },
+     {
+        "name": "LOGLEVEL",
+        "value": "${var.ranger_admin_loglevel}"
+     }
+    ]
+  }
+]
+EOF
+}
+
+data "template_file" "ranger_usersync" {
+  template = <<EOF
+[
+  {
+    "name": "ranger-usersync",
+    "image": "${var.ranger_docker_image}:${var.ranger_docker_version}",
+    "command": [ "/start-ranger-usersync.sh" ],
+    "essential": true,
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+            "awslogs-group": "${aws_cloudwatch_log_group.ranger.name}",
+            "awslogs-region": "${var.aws_region}",
+            "awslogs-stream-prefix": "/"
+        }
+    },
+    "environment":[
+     {
+        "name": "HEAPSIZE",
+        "value": "${var.ranger_usersync_task_memory}"
+     },
+     {
+        "name": "AWS_REGION",
+        "value": "${var.aws_region}"
+     },
+     {
+        "name": "VAULT_ADDR",
+        "value": "${var.vault_internal_addr}"
+     },
+     {
+        "name": "vault_path",
+        "value": "${local.vault_path}"
+     },
+     {
+        "name": "POLICY_MGR_URL",
+        "value": "http:\\/\\/${aws_lb.ranger_admin_lb.dns_name}:6080"
+     },
+     {
+        "name": "SYNC_LDAP_URL",
+        "value": "${replace(var.ldap_url,"/","\\\\/")}"
+
+     },
+     {
+        "name": "SYNC_LDAP_SEARCH_BASE",
+        "value": "${var.ldap_base}"
+     },
+     {
+        "name": "SYNC_LDAP_USER_SEARCH_BASE",
+        "value": "${var.ldap_user_base}"
+     },
+     {
+        "name": "SYNC_GROUP_SEARCH_BASE",
+        "value": "${var.ldap_group_base}"
+     },
+     {
+        "name": "SYNC_LDAP_USER_NAME_ATTRIBUTE",
+        "value": "sAMAccountName"
+     },
+     {
+        "name": "SYNC_GROUP_NAME_ATTRIBUTE",
+        "value": "sAMAccountName"
+     },
+     {
+        "name": "SYNC_PAGED_RESULTS_SIZE",
+        "value": "1000"
+     },
+     {
+        "name": "SYNC_INTERVAL",
+        "value": "${var.ldap_sync_interval}"
+     },
+     {
+        "name": "GROUP_BASED_ROLE_ASSIGNMENT_RULES",
+        "value": "${ var.ranger_admin_ldap_groups == "" ? "" : "\\\\&ROLE_SYS_ADMIN:g:${var.ranger_admin_ldap_groups}" }"
+     },
+     {
+        "name": "LOGLEVEL",
+        "value": "${var.ranger_usersync_loglevel}"
+     }
+    ]
+  }
+]
+EOF
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,194 @@
+/**
+ * Copyright (C) 2018 Expedia Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+variable "apiary_tags" {
+  description = "Common tags that get put on all resources"
+  type        = "map"
+}
+
+variable "vault_addr" {
+  description = "Address of vault server for secrets"
+  type        = "string"
+}
+
+variable "vault_internal_addr" {
+  description = "Address of vault server for secrets"
+  type        = "string"
+}
+
+variable "vault_path" {
+  description = "Path to apiary secrets in vault"
+  type        = "string"
+  default     = ""
+}
+
+variable "ranger_domain_name" {
+  description = "Route 53 domain name to register ranger-admin cname"
+  type        = "string"
+}
+
+variable "vpc_id" {
+  description = "VPC id"
+  type        = "string"
+}
+
+variable "private_subnets" {
+  description = "ranger admin subnets"
+  type        = "list"
+}
+
+variable "aws_region" {
+  description = "aws region"
+  type        = "string"
+}
+
+variable "ranger_database_name" {
+  description = "Database name to create in RDS for Apiary"
+  type        = "string"
+  default     = "ranger"
+}
+
+variable "ranger_db_additional_sg" {
+  description = "Comma-seperated string for additional security groups to attach to RDS"
+  type        = "list"
+  default     = []
+}
+
+variable "ranger_db_instance_class" {
+  description = "instance type for the rds metastore"
+  type        = "string"
+  default     = "db.t2.medium"
+}
+
+variable "ranger_db_instance_count" {
+  description = "desired count of database cluster instances"
+  type        = "string"
+  default     = "2"
+}
+
+variable "ranger_db_backup_retention" {
+  description = "The days to retain backups for, for the rds metastore."
+  type        = "string"
+  default     = "7"
+}
+
+variable "ranger_db_backup_window" {
+  description = "preferred backup window for rds metastore database in UTC."
+  type        = "string"
+  default     = "02:00-03:00"
+}
+
+variable "ranger_db_maintenance_window" {
+  description = "preferred maintenance window for rds metastore database in UTC."
+  type        = "string"
+  default     = "wed:03:00-wed:04:00"
+}
+
+variable "ranger_db_ingress_cidr" {
+  description = "ranger db ingress cidr list"
+  type        = "list"
+}
+
+variable "ranger_admin_ingress_cidr" {
+  description = "ranger admin ingress cidr list"
+  type        = "list"
+}
+
+variable "ranger_admin_instance_count" {
+  description = "desired count of the ranger admin service"
+  type        = "string"
+  default     = "2"
+}
+
+variable "ranger_admin_task_memory" {
+  description = "ranger admin container memory value, valid values: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html."
+  type        = "string"
+  default     = "4096"
+}
+
+variable "ranger_admin_task_cpu" {
+  description = "ranger admin container cpu value, valid values https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html"
+  type        = "string"
+  default     = "512"
+}
+
+variable "ranger_admin_loglevel" {
+  description = "ranger admin process loglevel,supports log4j values"
+  type        = "string"
+  default     = "info"
+}
+
+variable "audit_solr_urls" {
+  description = "ranger solr audit provider configuration,if not configured, defaults to db audit configuration"
+  type        = "string"
+  default     = ""
+}
+
+variable "ranger_usersync_task_memory" {
+  description = "ranger usersync container memory value, valid values: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html."
+  type        = "string"
+  default     = "4096"
+}
+
+variable "ranger_usersync_task_cpu" {
+  description = "ranger usersync container cpu value, valid values https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html"
+  type        = "string"
+  default     = "512"
+}
+
+variable "ranger_usersync_loglevel" {
+  description = "ranger usersync process loglevel,supports log4j values"
+  type        = "string"
+  default     = "info"
+}
+
+variable "ranger_docker_image" {
+  description = "docker image id for ranger"
+  type        = "string"
+}
+
+variable "ranger_docker_version" {
+  description = "version of the docker image for ranger"
+  type        = "string"
+}
+
+variable "ldap_url" {
+  description = "active directory ldap url to configure hadoop LDAP group mapping"
+  type        = "string"
+}
+
+variable "ldap_base" {
+  description = "active directory ldap base dn"
+  type        = "string"
+}
+
+variable "ldap_domain" {
+  description = "active directory ldap domain"
+  type        = "string"
+  default     = ""
+}
+
+variable "ldap_user_base" {
+  description = "active directory ldap base dn to search for users"
+  type        = "string"
+}
+
+variable "ldap_group_base" {
+  description = "active directory ldap base dn to search for groups"
+  type        = "string"
+}
+
+variable "ldap_sync_interval" {
+  description = "ranger usersync interval"
+  type        = "string"
+  default     = "120"
+}
+
+variable "ranger_admin_ldap_groups" {
+  description = "csv active directory groups to grant ROLE_SYS_ADMIN privileges"
+  type        = "string"
+  default     = ""
+}

--- a/vault.tf
+++ b/vault.tf
@@ -1,0 +1,10 @@
+/**
+ * Copyright (C) 2018 Expedia Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+provider "vault" {
+  address         = "${var.vault_addr}"
+  skip_tls_verify = "true"
+}


### PR DESCRIPTION
 Aurora database for storing ranger configs and audit logs
 ranger admin service HA configuration with sticky sessions.
 ranger usersync service to sync ldap users and groups from Active Directory
 read database master password from vault
 route53 dns entries for ranger admin & database
 *solr based auditing is not included in intial commit.