### PR TITLE
Fixes #4 - Tag resources that can be tagged.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- tag resources that were not yet applying tags - see [#4](https://github.com/ExpediaInc/apiary-authorization/issues/4).
+
 ## [1.0.0] - 2018-10-31
 ### Added
 - initial terraform: See [#1](https://github.com/ExpediaInc/apiary-authorization/issues/1)

--- a/iam.tf
+++ b/iam.tf
@@ -22,6 +22,8 @@ resource "aws_iam_role" "ranger_task_exec" {
   ]
 }
 EOF
+
+  tags = "${var.apiary_tags}"
 }
 
 resource "aws_iam_role_policy_attachment" "ranger_task_exec_policy" {
@@ -47,4 +49,6 @@ resource "aws_iam_role" "ranger_task" {
   ]
 }
 EOF
+
+  tags = "${var.apiary_tags}"
 }

--- a/ranger.tf
+++ b/ranger.tf
@@ -6,6 +6,7 @@
 
 resource "aws_ecs_cluster" "ranger" {
   name = "ranger"
+  tags = "${var.apiary_tags}"
 }
 
 resource "aws_cloudwatch_log_group" "ranger" {
@@ -26,6 +27,7 @@ resource "aws_ecs_task_definition" "ranger_admin" {
   cpu                      = "${var.ranger_admin_task_cpu}"
   requires_compatibilities = ["EC2", "FARGATE"]
   container_definitions    = "${data.template_file.ranger_admin.rendered}"
+  tags = "${var.apiary_tags}"
 }
 
 resource "aws_security_group" "ranger_admin" {
@@ -131,6 +133,7 @@ resource "aws_lb_target_group" "ranger_admin_tg" {
   vpc_id      = "${var.vpc_id}"
   target_type = "ip"
   slow_start  = 900
+  tags        = "${var.apiary_tags}"
 
   stickiness {
     type    = "lb_cookie"
@@ -209,6 +212,7 @@ resource "aws_ecs_task_definition" "ranger_usersync" {
   cpu                      = "${var.ranger_usersync_task_cpu}"
   requires_compatibilities = ["EC2", "FARGATE"]
   container_definitions    = "${data.template_file.ranger_usersync.rendered}"
+  tags                     = "${var.apiary_tags}"
 }
 
 resource "aws_ecs_service" "ranger_usersync" {


### PR DESCRIPTION
Fixes #4 

Unfortunately, this PR is not applying tags to ECS services, because Terraform doesn't support conditional logic in maps or lists, which we need to do conditional tagging based on whether or not the AWS account has opted-in to the longer ARN format for ECS services.